### PR TITLE
Tagged docker builds

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SHA=`git rev-parse --short HEAD`
+
+docker build -t earthlab/earth-analytics-python-env:$SHA .

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SHA=`git rev-parse --short HEAD`
+
+docker push earthlab/earth-analytics-python-env:$SHA


### PR DESCRIPTION
I think this uses the dockerhub automated build infrastructure but produces an image that is tagged with the git revision it was built from.

To experiment I setup a docker auto build for my fork of this repo and this is what I got: https://hub.docker.com/r/betatim/earth-analytics-python-env/tags/ This is with basically default setting on the docker hub side:
<img width="1034" alt="screen shot 2018-07-05 at 15 31 45" src="https://user-images.githubusercontent.com/1448859/42326149-966cd2fc-8068-11e8-81e5-fcea31571221.png">

So despite it saying "latest" as tag there, the tag is actually the git revision.