### PR TITLE
[MRG] Explicitly add libgdal to list of dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - folium
   - scikit-image
   - gdal
+  - libgdal
   - geocoder
   - geojson
 


### PR DESCRIPTION
This makes sure libgdal is pulled in from conda-forge instead of the
default channel.