### PR TITLE
Remove default channels, ensure rasterio is importable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,7 @@ RUN conda env update -n root -f environment.yml
 
 RUN conda info --envs
 
+RUN python -c "import rasterio"
+
 RUN rm environment.yml
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: earth-analytics-python
 channels:
+  - nodefaults
   - conda-forge
 dependencies:
   # Core scientific python


### PR DESCRIPTION
This PR removes the default conda channels, ensuring that everything gets installed from conda-forge. This is good, because conda-forge checks packages whose dependencies are on conda-forge. By avoiding a mixture of things installed from conda-forge and defaults, we should be able to avoid broken dependency issues. 

This also checks in the Dockerfile to ensure that rasterio can be imported, which should be helpful as this has been an issue previously. If rasterio can't be imported the Docker Hub automated build will fail. 

@lwasser take a look and please merge if this looks good to you