### PR TITLE
install geocoder and tweepy via pip

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   # Core scientific python
   - numpy
   - matplotlib
-  - python>=3.6
+  - python=3.7
   - pyqt
   - seaborn
   - tqdm

--- a/environment.yml
+++ b/environment.yml
@@ -26,12 +26,10 @@ dependencies:
   - gdal
   - libgdal
   - kealib
-#  - geocoder
   - geojson
   - earthpy
 
   # Natural language processing
-#  - tweepy
   - nltk
   - textblob
 

--- a/environment.yml
+++ b/environment.yml
@@ -26,12 +26,12 @@ dependencies:
   - gdal
   - libgdal
   - kealib
-  - geocoder
+#  - geocoder
   - geojson
   - earthpy
 
   # Natural language processing
-  - tweepy
+#  - tweepy
   - nltk
   - textblob
 
@@ -48,3 +48,5 @@ dependencies:
       - mapboxgl
       - hydrofunctions
       - scikit-learn
+      - geocoder
+      - tweepy


### PR DESCRIPTION
both packages are not currently on conda-forge. yucky.

There are currently several build issues. but one is specifically related to tweepy and geocoder not being currently on conda-forge yet they are current on pip. this should help with the python 3.6 issue. 

UPDATE: for some reason the errors i'm getting in my local build are not persisting on dockerhub. not sure why but it seems to be building now without issue.