### PR TITLE
starting to clean up the ea envt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM jupyter/scipy-notebook
+FROM jupyter/minimal-notebook
 
-MAINTAINER Max Joseph <maxwell.b.joseph@colorado.edu>
+MAINTAINER Leah Wasser <leah.wasser@colorado.edu>
 
 COPY environment.yml environment.yml
 

--- a/environment.yml
+++ b/environment.yml
@@ -23,22 +23,23 @@ dependencies:
   - earthpy
   - folium
   - geojson
-  # The items below are already in the conda distribution
-  - rasterio  # this is also in the conda distribution but i feel as if it should be installed w conda forge
-  - pysal
-  - pyproj
   - mapboxgl
   - hydrofunctions
   - geocoder
   - tweepy
   
+  # The items below are already in the conda distribution
+  - rasterio  # this is also in the conda distribution but i feel as if it should be installed w conda forge
+  - pysal
+  - pyproj
+
   # Natural language processing
   #- nltk #already in the anaconda distribution
   - textblob
 
   # Jupyter Environment
   - autopep8
-  #- notebook
+  #- notebook # i don't think we need this either. it was the case i had a dated version of notebook... 
   # I don't think we need ipython
   #- ipython
   # This is not in anaconda explicetly 

--- a/environment.yml
+++ b/environment.yml
@@ -41,10 +41,9 @@ dependencies:
   - notebook 
   # Do we need this?
   - ipython
-  # This is not in anaconda explicetly 
   - jupyter_contrib_nbextensions
   - nbclean
-  # Natural language processing
+  # Autograding
   - matplotcheck
   - nbgrader
 

--- a/environment.yml
+++ b/environment.yml
@@ -19,28 +19,29 @@ dependencies:
   - geopy
   - cartopy
   - geopandas
-  - rasterio
   - contextily
-  - pysal
-  - pyproj
+  - earthpy
   - folium
   - geojson
-  - earthpy
-
+  # The items below are already in the conda distribution
+  - rasterio  # this is also in the conda distribution but i feel as if it should be installed w conda forge
+  - pysal
+  - pyproj
+  - mapboxgl
+  - hydrofunctions
+  - geocoder
+  - tweepy
+  
   # Natural language processing
-  - nltk
+  #- nltk #already in the anaconda distribution
   - textblob
 
   # Jupyter Environment
   - autopep8
-  - notebook
-  - ipython
+  #- notebook
+  # I don't think we need ipython
+  #- ipython
+  # This is not in anaconda explicetly 
   - jupyter_contrib_nbextensions
-  - jupyterlab
-  - nb_conda
   - nbclean
-  - mapboxgl
-  - hydrofunctions
-  - scikit-learn
-  - geocoder
-  - tweepy
+

--- a/environment.yml
+++ b/environment.yml
@@ -15,13 +15,13 @@ dependencies:
   - kiwisolver
 
   # Spatial packages
-  - rasterio  
+  #- rasterio  
   - pysal
   - pyproj
   - rasterstats
   - geopy
   - cartopy
-  - geopandas
+  #- geopandas
   - contextily
   - earthpy
   - folium

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,9 @@ dependencies:
   - kiwisolver
 
   # Spatial packages
+  - rasterio  
+  - pysal
+  - pyproj
   - rasterstats
   - geopy
   - cartopy
@@ -27,22 +30,21 @@ dependencies:
   - hydrofunctions
   - geocoder
   - tweepy
-  
-  # The items below are already in the conda distribution
-  - rasterio  # this is also in the conda distribution but i feel as if it should be installed w conda forge
-  - pysal
-  - pyproj
 
   # Natural language processing
-  #- nltk #already in the anaconda distribution
+  - nltk 
   - textblob
 
   # Jupyter Environment
   - autopep8
-  #- notebook # i don't think we need this either. it was the case i had a dated version of notebook... 
-  # I don't think we need ipython
-  #- ipython
+  - jupyterlab
+  - notebook 
+  # Do we need this?
+  - ipython
   # This is not in anaconda explicetly 
   - jupyter_contrib_nbextensions
   - nbclean
+  # Natural language processing
+  - matplotcheck
+  - nbgrader
 


### PR DESCRIPTION
@kcranston here is my start at cleaning up the envt.

some of these packages are ALREADY in the conda install. so we might not need them in this YAML but want them in our docker container 

i'm not sure what is best

1. include what we need here even if it's in the conda install hat students use and because we use conda forge as the priority channel. rasterio is an example of this 
2. remove them here but install via the dockerfile for the hub

@ocefpaf what do you suggest in the case where we are using the continuum download of anaconda for our classes. We install this environment on TOP of that download. some packages like rasterio are already in there.

however we also use this same environment for our docker container on our jupyterhub. in that example we are using a more minimal miniconda base with jupyter on top and might need to install rasterio for example there. Should i consider installing some things like rasterio only in the dockerfile? what is the best practice from conda-forge's perspective?