### PR TITLE
unpin nbgrader now that new release available

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -45,5 +45,5 @@ dependencies:
   - nbclean
   # Autograding
   - matplotcheck
-  - nbgrader=0.5.6
+  - nbgrader
 


### PR DESCRIPTION
See #57 . We need to get 0.6.0 in order to have all of the merged nbgrader feature branches (otherwise, we miss bug fixes that cause issues with manual grading). 