### PR TITLE
source base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ COPY environment.yml environment.yml
 RUN conda env update -n root -f environment.yml \
   && conda info --envs \
   && conda list \
-  && rm environment.yml
+  && rm environment.yml \
+  && . activate base
 
 # Test imports
 RUN python -c "import rasterio"


### PR DESCRIPTION
@lwasser `conda init` needs a proper shell and it looks like your base image cannot do `source activate` as well. So let's go old school and use the `.`. This should activate the `base` environment (formerly known as `root`). 