### PR TITLE
add papermill to build

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -36,10 +36,10 @@ dependencies:
   - textblob
 
   # Jupyter Environment
+  - papermill
   - autopep8
   - jupyterlab
   - notebook 
-  # Do we need this?
   - ipython
   - jupyter_contrib_nbextensions
   - nbclean


### PR DESCRIPTION
papermill is ideal to run notebooks. it's easier if it's just installed natively for our CI tests!! 