### PR TITLE
Update to 3.12 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN . /opt/conda/etc/profile.d/conda.sh && conda activate base && python -m ipyk
 RUN source /home/jovyan/.bash_profile
 
 # Install dev version of Earthpy
-RUN pip install git+https://github.com/earthlab/earthpy@apppears
+RUN pip install git+https://github.com/earthlab/earthpy@main

--- a/environment.yml
+++ b/environment.yml
@@ -4,13 +4,14 @@ channels:
   - defaults
 
 dependencies:
-  - python=3.11
+  - python=3.12
   - pip
   
   # Core scientific python
   - numpy
   - pandas
   - scipy
+  - dask
 
   # Geospatial libraries
   # Coordinates and CRSs
@@ -46,6 +47,9 @@ dependencies:
   - earthpy
   - earthaccess
   - pystac-client
+  - adlfs
+  - dataretrieval
+  - osmnx
   
   # Plotting
   # Matplotlib
@@ -55,6 +59,8 @@ dependencies:
   - contextily
   - seaborn
   # Holoviews
+  # --- Avoid compatibility issues with bokeh and new holoviews
+  - holoviews<=1.19
   - hvplot
   - geoviews>=1.10
   - selenium
@@ -70,3 +76,6 @@ dependencies:
   - autopep8
   - pydocstyle
   - nbqa
+
+  - pip:
+    - pygbif


### PR DESCRIPTION
## Description

This update moves to Python 3.12. It also addresses an issue with the Holoview's package and a new bokeh version by temporarily pinning, and adds some additional libraries that are used in newer curriculum.

Fixes #101 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Environment build was tested in GitHub Actions in the update-to-3.12 branch.


## Checklist:

- [x] I have already submitted an issue and i was invited to submit a pr by an earthdatascience.org maintainer
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
